### PR TITLE
[TOOL-104] Fixing win related regex error.

### DIFF
--- a/src/ProgramOptions.cpp
+++ b/src/ProgramOptions.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <fstream>
 #include <functional>
+#define _REGEX_MAX_STACK_COUNT 200000
 #include <regex>
 #include "HelpException.h"
 #include "external/cxxopts.hpp"


### PR DESCRIPTION
Sometimes on win machinbes we can receive regex_error(error_stack): There was insufficient memory to determine whether the regular expression could match the specified character sequence. For example we can see this behaviour if in font we will have some russian or asian symbols.
